### PR TITLE
only normalize whitespace for 2+ occurrences

### DIFF
--- a/__tests__/xmlNormalize.test.ts
+++ b/__tests__/xmlNormalize.test.ts
@@ -257,6 +257,15 @@ describe('xmlNormalize', () => {
                 .toEqual('<root><node>a a</node><node>x x <mixed>m m</mixed></node></root>');
 
         });
+        test('should keep single non-breaking spaces', () => {
+            expect(xmlNormalize({
+                ...defaultOptions,
+                normalizeWhitespace: true,
+                in: '<root><node> a  a</node><node> x x <mixed>m   m </mixed></node></root>'
+            }))
+                .toEqual('<root><node>a a</node><node>x x <mixed>m m</mixed></node></root>');
+
+        });
         test('should keep single whitespace between nodes mixed with text', () => {
             expect(xmlNormalize({
                 ...defaultOptions,

--- a/src/xmlNormalize.ts
+++ b/src/xmlNormalize.ts
@@ -26,7 +26,7 @@ function trimTextNodes(doc: XmlDocument, trim: boolean, trimMixed: boolean, norm
             docElement.children.forEach(((value, index, arr) => {
                 if (value.type === 'text') {
                     if (normalize) {
-                        value.text = value.text.replace(/\s+/g, ' ');
+                        value.text = value.text.replace(/\s{2,}/g, ' ');
                     }
                     if (trim && !isWhiteSpace(value)) {
                         if (trimMixed || index === 0 || arr[index - 1].type !== 'element') {


### PR DESCRIPTION
This avoids replacing single instances of non-breaking spaces (NBSP) with a regular space, which can cause problems for certain languages or style guides.

For example, French texts might include an NBSP before a question mark. Measurements such as "100 km" might also use an NBSP depending on editor preference.

This change does not prevent multiple NBSPs, or a single NBSP followed by regular spaces, from being replaced by a single regular space. I think think this is acceptable as this falls outside of valid usage of NBSPs, and addressing this case might introduce more complexity.

Happy to consider alternative solutions if you think this breaks the concept of normalisation.