### PR TITLE
enable sorting of attributes

### DIFF
--- a/__tests__/xmlNormalize.test.ts
+++ b/__tests__/xmlNormalize.test.ts
@@ -239,6 +239,23 @@ describe('xmlNormalize', () => {
                 .toEqual('<root><node id="a a">a</node><node id="b b">x<mixed>m</mixed></node></root>');
 
         });
+        test('should normalize attribute order', () => {
+            expect(xmlNormalize({
+                ...defaultOptions,
+                in: '<root><node x=" a   a" a="first">a</node><node b="   keep first " x="last">x<mixed>m</mixed></node></root>'
+            }))
+                .toEqual('<root><node a="first" x="a   a">a</node><node b="keep first" x="last">x<mixed>m</mixed></node></root>');
+
+        });
+        test('should not normalize attribute order', () => {
+            expect(xmlNormalize({
+                ...defaultOptions,
+                normalizeAttributeOrder: false,
+                in: '<root><node x=" a   a" a="first">a</node><node b="   keep first " x="last">x<mixed>m</mixed></node></root>'
+            }))
+                .toEqual('<root><node x="a   a" a="first">a</node><node b="keep first" x="last">x<mixed>m</mixed></node></root>');
+
+        });
         test('should not normalize attributes when disabled', () => {
             expect(xmlNormalize({
                 ...defaultOptions,

--- a/__tests__/xmlNormalize.test.ts
+++ b/__tests__/xmlNormalize.test.ts
@@ -242,6 +242,7 @@ describe('xmlNormalize', () => {
         test('should normalize attribute order', () => {
             expect(xmlNormalize({
                 ...defaultOptions,
+                normalizeAttributeOrder: true,
                 in: '<root><node x=" a   a" a="first">a</node><node b="   keep first " x="last">x<mixed>m</mixed></node></root>'
             }))
                 .toEqual('<root><node a="first" x="a   a">a</node><node b="keep first" x="last">x<mixed>m</mixed></node></root>');
@@ -250,7 +251,6 @@ describe('xmlNormalize', () => {
         test('should not normalize attribute order', () => {
             expect(xmlNormalize({
                 ...defaultOptions,
-                normalizeAttributeOrder: false,
                 in: '<root><node x=" a   a" a="first">a</node><node b="   keep first " x="last">x<mixed>m</mixed></node></root>'
             }))
                 .toEqual('<root><node x="a   a" a="first">a</node><node b="keep first" x="last">x<mixed>m</mixed></node></root>');

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const options = new Command()
     .option('--no-pretty', 'Disable pretty format output')
     .option('--no-trim', 'Disable trimming of whitespace at the beginning and end of text nodes (trims only pure text nodes)')
     .option('--no-attribute-trim', 'Disable trimming whitespace at the beginning and end of attribute values')
-    .option('--no-attribute-order', 'Disable reordering of attributes')
+    .option('--normalize-attribute-order', 'Enable reordering of attributes')
     .option('-tf, --trim-force', 'Trim the whitespace at the beginning and end of text nodes (trims as well text adjacent to nested nodes)')
     .option('-n, --normalize-whitespace', 'Normalize whitespaces inside text nodes and attribute values')
     .option('-d, --debug', 'enable debug output')
@@ -35,7 +35,7 @@ const outString = xmlNormalize({
     trimForce: options.trimForce,
     attributeTrim: options.attributeTrim,
     normalizeWhitespace: options.normalizeWhitespace,
-    normalizeAttributeOrder: options.attributeOrder,
+    normalizeAttributeOrder: options.normalizeAttributeOrder,
     pretty: options.pretty
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const options = new Command()
     .option('--no-pretty', 'Disable pretty format output')
     .option('--no-trim', 'Disable trimming of whitespace at the beginning and end of text nodes (trims only pure text nodes)')
     .option('--no-attribute-trim', 'Disable trimming whitespace at the beginning and end of attribute values')
+    .option('--no-attribute-order', 'Disable reordering of attributes')
     .option('-tf, --trim-force', 'Trim the whitespace at the beginning and end of text nodes (trims as well text adjacent to nested nodes)')
     .option('-n, --normalize-whitespace', 'Normalize whitespaces inside text nodes and attribute values')
     .option('-d, --debug', 'enable debug output')
@@ -34,6 +35,7 @@ const outString = xmlNormalize({
     trimForce: options.trimForce,
     attributeTrim: options.attributeTrim,
     normalizeWhitespace: options.normalizeWhitespace,
+    normalizeAttributeOrder: options.attributeOrder,
     pretty: options.pretty
 });
 

--- a/src/xmlNormalize.ts
+++ b/src/xmlNormalize.ts
@@ -18,7 +18,7 @@ export interface XmlNormalizeOptions {
     normalizeWhitespace?: boolean;
     /** default: `true` */
     pretty?: boolean;
-    /** default: `true` */
+    /** default: `false` */
     normalizeAttributeOrder?: boolean;
 }
 
@@ -122,7 +122,7 @@ export function xmlNormalize(options: XmlNormalizeOptions) {
         doc = trimTextNodes(doc, options.trim ?? true, options.trimForce ?? false, options.normalizeWhitespace ?? false);
     }
 
-    const optionNormalizeAttributeOrder = options.normalizeAttributeOrder ?? true;
+    const optionNormalizeAttributeOrder = options.normalizeAttributeOrder ?? false;
     if ((options.attributeTrim ?? true) || (options.normalizeWhitespace ?? false) || optionNormalizeAttributeOrder) {
         doc = trimAttributeValues(doc, options.normalizeWhitespace ?? false, 
             options.attributeTrim ?? true,

--- a/src/xmlNormalize.ts
+++ b/src/xmlNormalize.ts
@@ -18,6 +18,8 @@ export interface XmlNormalizeOptions {
     normalizeWhitespace?: boolean;
     /** default: `true` */
     pretty?: boolean;
+    /** default: `true` */
+    normalizeAttributeOrder?: boolean;
 }
 
 function trimTextNodes(doc: XmlDocument, trim: boolean, trimMixed: boolean, normalize: boolean): XmlDocument {
@@ -43,15 +45,23 @@ function trimTextNodes(doc: XmlDocument, trim: boolean, trimMixed: boolean, norm
     return doc;
 }
 
-function trimAttributeValues(doc: XmlDocument, normalize: boolean) {
+function trimAttributeValues(doc: XmlDocument, normalize: boolean, trim: boolean, sort: boolean) {
     for (const docElement of new Evaluator(doc).allChildren()) {
         if (docElement.type === 'element') {
-            Object.keys(docElement.attr)
+            const attributeValues = {...docElement.attr};
+            const attributeList = Object.keys(docElement.attr);
+            if (sort) {
+                attributeList.sort();
+                docElement.attr = {};
+            }
+            attributeList
                 .forEach(attrName => {
                     if (normalize) {
-                        docElement.attr[attrName] = docElement.attr[attrName].trim().replace(/\s+/g, ' ');
+                        docElement.attr[attrName] = attributeValues[attrName].trim().replace(/\s+/g, ' ');
+                    } else if(trim) {
+                        docElement.attr[attrName] = attributeValues[attrName].trim();
                     } else {
-                        docElement.attr[attrName] = docElement.attr[attrName].trim();
+                        docElement.attr[attrName] = attributeValues[attrName];
                     }
                 });
         }
@@ -112,8 +122,11 @@ export function xmlNormalize(options: XmlNormalizeOptions) {
         doc = trimTextNodes(doc, options.trim ?? true, options.trimForce ?? false, options.normalizeWhitespace ?? false);
     }
 
-    if ((options.attributeTrim ?? true) || (options.normalizeWhitespace ?? false)) {
-        doc = trimAttributeValues(doc, options.normalizeWhitespace ?? false);
+    const optionNormalizeAttributeOrder = options.normalizeAttributeOrder ?? true;
+    if ((options.attributeTrim ?? true) || (options.normalizeWhitespace ?? false) || optionNormalizeAttributeOrder) {
+        doc = trimAttributeValues(doc, options.normalizeWhitespace ?? false, 
+            options.attributeTrim ?? true,
+            optionNormalizeAttributeOrder);
     }
 
     if (options.pretty ?? true) {


### PR DESCRIPTION
this is needed because some translation tools mix the attribute order in xliff files.
So that the xliff-simple-merge tool is working properly. 